### PR TITLE
Fix a minor typo in help message

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -31,7 +31,7 @@ Hypercane is a research project and is rather volatile. These actions will remai
 
    # hc report --help
 
-   'hc report' is used print reports about web archive collections
+   'hc report' is used to print reports about web archive collections
 
    Supported commands:
    * metadata - for discovering the metadata associated with seeds

--- a/hypercane/actions/report.py
+++ b/hypercane/actions/report.py
@@ -501,7 +501,7 @@ def report_growth_curve_stats(args):
 
 def print_usage():
 
-    print("""'hc report' is used print reports about web archive collections
+    print("""'hc report' is used to print reports about web archive collections
 
     Supported commands:
     * metadata - for discovering the metadata associated with seeds


### PR DESCRIPTION
`is used print reports` => `is used to print reports`