### PR TITLE
Write database details to correct file

### DIFF
--- a/hypercane-gui/set-hypercane-database.sh
+++ b/hypercane-gui/set-hypercane-database.sh
@@ -102,11 +102,11 @@ fi
 settings_file=${WOOEY_DIR}/hypercane_with_wooey/settings/user_settings.py
 hypercane_conf=/etc/hypercane.conf
 
-echo "writing database information to ${settings_file}"
+echo "writing database information to ${hypercane_conf}"
 
 MDB_line=`grep HC_CACHE_STORAGE ${settings_file}`
 
-cat >> ${raintale_conf} <<- EOF
+cat >> ${hypercane_conf} <<- EOF
 ${MDB_line}
 DATABASE_NAME="${DBNAME}"
 DATABASE_PORT="${DBPORT}"


### PR DESCRIPTION
Currently we're writing to `${raintale_conf}` which is not declared and printing that we're writing the database details to `${settings_file}` but it looks like we should actually be writing to `${hypercane_conf}`.